### PR TITLE
pfa/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ compiler:
   - gcc
 
 before_script:
-  - mkdir build
-  - cd build
+  - mkdir workspace
+  - cd workspace
   - cmake
 
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
 
 before_script:
   - sudo apt-get update -qq
-  - sudo apt-get install -y swig2.0 tshark check rsync libpcap-dev gawk libedit-dev libpcre3-dev
+  - sudo apt-get install -y swig2.0 tshark check rsync libpcap-dev gawk libedit-dev libpcre3-dev uuid-dev
   - mkdir workspace
   - cd workspace
   - cmake ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ compiler:
   - gcc
 
 before_script:
+  - wget http://heanet.dl.sourceforge.net/project/swig/swig/swig-2.0.11/swig-2.0.11.tar.gz
+  - tar xzf swig-2.0.11.tar.gz
+  - cd swig-2.0.11/ && ./configure --prefix=/usr && make && sudo make install
+  - cd ../
   - sudo apt-get update -qq
-  - sudo apt-get install -y swig2.0 tshark check rsync libpcap-dev gawk libedit-dev libpcre3-dev uuid-dev
+  - sudo apt-get install -y tshark check rsync libpcap-dev gawk libedit-dev libpcre3-dev uuid-dev
   - mkdir workspace
   - cd workspace
   - cmake ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 compiler:
   - gcc
 
-before_script:
+install:
   - wget http://heanet.dl.sourceforge.net/project/swig/swig/swig-2.0.11/swig-2.0.11.tar.gz
   - tar xzf swig-2.0.11.tar.gz
   - cd swig-2.0.11/ && ./configure --prefix=/usr && make && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_script:
   - cd swig-2.0.11/ && ./configure --prefix=/usr && make && sudo make install
   - cd ../
   - sudo apt-get update -qq
-  - sudo apt-get install -y tshark check rsync libpcap-dev gawk libedit-dev libpcre3-dev uuid-dev
+  - sudo apt-get install -y tshark check rsync libpcap-dev gawk libedit-dev libpcre3-dev uuid-dev valgrind
   - mkdir workspace
   - cd workspace
   - cmake ../
 
-script: make
+script: make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+
+compiler:
+  - gcc
+
+before_script:
+  - mkdir build
+  - cd build
+  - cmake
+
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ compiler:
   - gcc
 
 before_script:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y swig2.0 tshark check rsync libpcap-dev gawk libedit-dev libpcre3-dev
   - mkdir workspace
   - cd workspace
   - cmake ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ compiler:
 before_script:
   - mkdir workspace
   - cd workspace
-  - cmake
+  - cmake ../
 
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_script:
   - cd workspace
   - cmake ../
 
-script: make tests
+script: CTEST_OUTPUT_ON_FAILURE=1 make tests

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/paulfariello/haka.svg?branch=master)](https://travis-ci.org/paulfariello/haka)
 
 HAKA Runtime
 ============

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/paulfariello/haka.svg?branch=master)](https://travis-ci.org/paulfariello/haka)
+[![Build Status](https://travis-ci.org/haka-security/haka.svg?branch=master)](https://travis-ci.org/haka-security/haka)
 
 HAKA Runtime
 ============


### PR DESCRIPTION
Add travis-ci build script support.

We have to create an account on travis-ci.com and then the build image can be added to the README.md.

![build status on pfa/travis](https://travis-ci.org/paulfariello/haka.svg?branch=pfa%2Ftravis)